### PR TITLE
CMS-1011 Display country guides on markets page

### DIFF
--- a/article/templates/article/components/landing_page_card.html
+++ b/article/templates/article/components/landing_page_card.html
@@ -1,0 +1,16 @@
+{% load parse_date from article_tags %}
+
+<div class="card">
+  <a class="card-link" href="{{ listing.full_path }}">
+    <div class="card-image" {% if listing.hero_image_thumbnail %}role="image" style="background-image: url('{{ listing.hero_image_thumbnail.url }}');"{% endif %} aria-label="{{ listing.landing_page_title }}" title="{{ listing.landing_page_title }}">
+      <p class="visually-hidden">{{ listing.landing_page_title }}</p>
+    </div>
+    <div class="card-inner">
+      <h3 class="heading-large">{{ listing.landing_page_title }}</h3>
+      <p class="description subheading">Updated {{ listing.last_published_at|parse_date }}</p>
+      {% if listing.articles_count %}
+      <p class="description subheading">{{ listing.articles_count }} guide{{ listing.articles_count|pluralize }}</p>
+      {% endif %}
+    </div>
+  </a>
+</div>

--- a/article/templates/article/markets_landing_page.html
+++ b/article/templates/article/markets_landing_page.html
@@ -1,0 +1,16 @@
+{% extends 'article/topic_list_base.html' %}
+
+{% block child_pages %}
+  <div class="grid-row margin-vertical-60">
+    <div class="column-full column-half-l font-medium">
+      Find market guides for British businesses interested in selling goods and services overseas.
+    </div>
+  </div>
+  <div class="card-grid">
+    {% for listing in page.child_pages %}
+        <div class="column-full column-third-l column-half-m">
+          {% include 'article/components/landing_page_card.html' with listing=listing %}
+        </div>
+    {% endfor %}
+  </div>
+{% endblock child_pages %}

--- a/article/templates/article/markets_landing_page.html
+++ b/article/templates/article/markets_landing_page.html
@@ -1,11 +1,13 @@
 {% extends 'article/topic_list_base.html' %}
 
 {% block child_pages %}
-  <div class="grid-row margin-vertical-60">
-    <div class="column-full column-half-l font-medium">
-      Find market guides for British businesses interested in selling goods and services overseas.
+  {% if page.teaser %}
+    <div class="grid-row margin-vertical-60">
+      <div class="column-full column-half-l font-medium">
+        {{ page.teaser }}
+      </div>
     </div>
-  </div>
+  {% endif %}
   <div class="card-grid">
     {% for listing in page.child_pages %}
         <div class="column-full column-third-l column-half-m">

--- a/article/templates/article/topic_list.html
+++ b/article/templates/article/topic_list.html
@@ -1,46 +1,13 @@
-{% extends 'article/base.html' %}
-{% load static %}
-{% load parse_date from article_tags %}
+{% extends 'article/topic_list_base.html' %}
 
-{% block css_layout_class %}article-list-page{% endblock css_layout_class %}
-
-{% block content %}
-
-{% block hero %}
-  <section class="hero hero-generic padding-0" {% if page.hero_image %}style="background-image: url('{{ page.hero_image.url }}')"{% endif %}>
-    <div class="container">
-      <div class="hero-title-compact">
-        <h1 class="heading-hero-generic{% if page.breadcrumbs_label|length > 15 %}-compact{% endif %}" id="hero-heading">{{ page.landing_page_title }}</h1>
-      </div>
-    </div>
-  </section>
-{% endblock %}
-
-<section class="topic-list-section">
-  {% block breadcrumbs %}
-    {% include 'article/components/breadcrumbs.html' with breadcrumbs=breadcrumbs %}
-  {% endblock %}
-    <div class="container">
-      <div class="card-grid">
-        {% for listing in page.child_pages %}
-          {% if listing.articles_count > 0 %}
-            <div class="column-full column-third-l column-half-m">
-              <div class="card">
-                <a class="card-link" href="{{ listing.full_path }}">
-                  <div class="card-image" {% if listing.hero_image_thumbnail %}role="image" style="background-image: url('{{ listing.hero_image_thumbnail.url }}');"{% endif %} aria-label="{{ listing.landing_page_title }}" title="{{ listing.landing_page_title }}">
-                    <p class="visually-hidden">{{ listing.landing_page_title }}</p>
-                  </div>
-                  <div class="card-inner">
-                    <h3 class="heading-large">{{ listing.landing_page_title }}</h3>
-                      <p class="description subheading">Updated {{ listing.last_published_at|parse_date }}</p>
-                      <p class="description subheading">{{ listing.articles_count }} guide{{ listing.articles_count|pluralize }}</p>
-                  </div>
-                </a>
-              </div>
-            </div>
-          {% endif %}
-        {% endfor %}
-      </div>
-    </div>
-</section>
-{% endblock %}
+{% block child_pages %}
+  <div class="card-grid">
+    {% for listing in page.child_pages %}
+      {% if listing.articles_count > 0 %}
+        <div class="column-full column-third-l column-half-m">
+          {% include 'article/components/landing_page_card.html' with listing=listing %}
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endblock child_pages %}

--- a/article/templates/article/topic_list_base.html
+++ b/article/templates/article/topic_list_base.html
@@ -1,0 +1,25 @@
+{% extends 'article/base.html' %}
+
+{% block css_layout_class %}article-list-page{% endblock css_layout_class %}
+
+{% block content %}
+
+{% block hero %}
+  <section class="hero hero-generic padding-0" {% if page.hero_image %}style="background-image: url('{{ page.hero_image.url }}')"{% endif %}>
+    <div class="container">
+      <div class="hero-title-compact">
+        <h1 class="heading-hero-generic{% if page.breadcrumbs_label|length > 15 %}-compact{% endif %}" id="hero-heading">{{ page.landing_page_title }}</h1>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+<section class="topic-list-section">
+  {% block breadcrumbs %}
+    {% include 'article/components/breadcrumbs.html' with breadcrumbs=breadcrumbs %}
+  {% endblock %}
+  <div class="container">
+    {% block child_pages %}{% endblock %}
+  </div>
+</section>
+{% endblock %}

--- a/article/tests/test_views.py
+++ b/article/tests/test_views.py
@@ -1009,3 +1009,29 @@ def test_get_country_guide_page_non_viable_accordion(
 
     accordions = response.context_data['page']['accordions']
     assert bool(accordions[0]['is_viable']) is False
+
+
+@patch('directory_cms_client.client.cms_api_client.lookup_by_slug')
+def test_get_markets_page_renames_heading_to_landing_page_title(
+    mock_get_page, client
+):
+    page = {
+        'title': 'test',
+        'page_type': 'TopicLandingPage',
+        'child_pages': [
+            {
+                'heading': 'heading'
+            }
+        ]
+    }
+
+    mock_get_page.return_value = create_response(
+        status_code=200,
+        json_body=page
+    )
+
+    url = reverse('markets')
+    response = client.get(url)
+
+    child_page = response.context_data['page']['child_pages'][0]
+    assert child_page['landing_page_title'] is 'heading'

--- a/article/tests/test_views.py
+++ b/article/tests/test_views.py
@@ -132,6 +132,7 @@ def test_markets_link_in_header_when_feature_on(
         status_code=200,
         json_body={
             'page_type': 'TopicLandingPage',
+            'child_pages': []
         }
     )
     url = reverse('markets')

--- a/article/tests/test_views.py
+++ b/article/tests/test_views.py
@@ -113,7 +113,8 @@ def test_markets_pages_200_when_feature_on(
             'heading': 'Heading',
             'statistics': [],
             'accordions': [],
-            'fact_sheet': {'columns': []}
+            'fact_sheet': {'columns': []},
+            'child_pages': []
         }
     )
 
@@ -1034,4 +1035,4 @@ def test_get_markets_page_renames_heading_to_landing_page_title(
     response = client.get(url)
 
     child_page = response.context_data['page']['child_pages'][0]
-    assert child_page['landing_page_title'] is 'heading'
+    assert child_page['landing_page_title'] == 'heading'

--- a/article/views.py
+++ b/article/views.py
@@ -44,7 +44,19 @@ class CMSPageView(
 
 
 class MarketsPageView(MarketsFeatureFlagMixin, CMSPageView):
-    pass
+    template_name = 'article/markets_landing_page.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(MarketsPageView, self).get_context_data(**kwargs)
+
+        def rename_heading_field(page):
+            page['landing_page_title'] = page['heading']
+            return page
+
+        context['page']['child_pages'] = [rename_heading_field(child_page)
+                                          for child_page
+                                          in context['page']['child_pages']]
+        return context
 
 
 class CountryGuidePageView(MarketsFeatureFlagMixin, CMSPageView):


### PR DESCRIPTION
Mmmm.... not particularly happy about this.

Landing pages are already used for advice articles, and they have a subtly different styling _and_ the structure of the response from the CMS is subtly different, leading to some painful mapping...