### PR TITLE
[XOT-716] Hide company number field if specified

### DIFF
--- a/contact/templates/contact/soo/step-organisation.html
+++ b/contact/templates/contact/soo/step-organisation.html
@@ -37,17 +37,25 @@
 {% block body_js %}
     <script src="{% static 'js/company-lookup.js' %}"></script>
     <script type="text/javascript">
+      var $companyNumberContainer = $("#id_organisation-company_number-container");
+      var $companyNumberField = $("#id_organisation-company_number");
+      var $noCompanyNumber = $("#id_organisation-soletrader");
+      function hideCompanyNumberFieldContainer() {
+        $companyNumberField.val("");
+        $companyNumberContainer.hide();
+      }
+      // hide company number field container if checkbox is checked before page is loaded fully
+      if($noCompanyNumber.is(":checked")) {
+        hideCompanyNumberFieldContainer();
+      }
+
       $(document).ready(function() {
-        var $companyNumberContainer = $("#id_organisation-company_number-container");
-        var $companyNumberField = $("#id_organisation-company_number");
-        var $noCompanyNumber = $("#id_organisation-soletrader");
         var lookup = new GOVUK.components.CompaniesHouseNameLookup($("#id_organisation-company_name"), $companyNumberField);
 
         // Hide and clear company number field if declare they have no number.
         $noCompanyNumber.on("change", function() {
           if(this.checked) {
-            $companyNumberField.val("");
-            $companyNumberContainer.hide();
+            hideCompanyNumberFieldContainer();
           }
           else {
             $companyNumberContainer.show();


### PR DESCRIPTION
Seems like it could be done using python class attributes, but there is no way to hide entire field group. 

Just to note `company_number` field cannot have hidden input since user can uncheck the box.