### PR TITLE
[XOT-733] Soo ingress always to landing

### DIFF
--- a/contact/templates/contact/submit-success-content.html
+++ b/contact/templates/contact/submit-success-content.html
@@ -17,6 +17,6 @@
   <div class="container">
     <h2 class="heading-large">{{ page.next_title }}</h2>
     <p class="body-text">{{ page.next_body_text }}</p>
-    <a class="link" href="{{ next_url }}">Continue to great.gov.uk</a>
+    <a class="link" href="{{ next_url }}">{{ next_url_text|default:"Continue to great.gov.uk" }}</a>
   </div>
 </section>

--- a/contact/tests/test_views.py
+++ b/contact/tests/test_views.py
@@ -843,6 +843,7 @@ def test_soo_ingress_url_special_cases_on_success(
         )
     # for contact ingress urls user flow continues to landing page
     assert response.context_data['next_url'] == mocked_soo_landing
+    assert response.context_data['next_url_text'] == 'Go back to Selling Online Overseas'
     assert response.status_code == 200
     # and the ingress url is cleared
     assert mock_clear.call_count == 1

--- a/contact/tests/test_views.py
+++ b/contact/tests/test_views.py
@@ -758,6 +758,7 @@ success_urls = (
     reverse('contact-us-feedback-success'),
     reverse('contact-us-domestic-success'),
     reverse('contact-us-international-success'),
+    reverse('contact-us-selling-online-overseas-success'),
 )
 
 
@@ -800,18 +801,48 @@ def test_ingress_url_special_cases_on_success(
         status_code=200,
         json_body={}
     )
-    # given the ingress url is set
+    # /contact/<path> should always return to landing
     client.get(
         reverse('contact-us-routing-form', kwargs={'step': 'location'}),
         HTTP_REFERER='http://testserver.com/contact/',
         HTTP_HOST='testserver.com'
     )
-
-    # when the success page is viewed
     response = client.get(url, HTTP_HOST='testserver.com')
-
     # for contact ingress urls user flow continues to landing page
     assert response.context_data['next_url'] == '/'
+    assert response.status_code == 200
+    # and the ingress url is cleared
+    assert mock_clear.call_count == 1
+
+
+@mock.patch('directory_cms_client.client.cms_api_client.lookup_by_slug')
+@mock.patch.object(views.FormSessionMixin.form_session_class, 'clear')
+def test_soo_ingress_url_special_cases_on_success(
+    mock_clear, mock_lookup_by_slug, client, rf
+):
+    mock_clear.return_value = None
+    mock_lookup_by_slug.return_value = create_response(
+        status_code=200,
+        json_body={}
+    )
+    # /selling-online-overseas/<path> should always return to soo landing
+    mocked_soo_landing = 'http://testserver.com/selling-online-overseas/'
+    client.get(
+        reverse('contact-us-soo', kwargs={'step': 'organisation'}),
+        HTTP_REFERER=mocked_soo_landing + 'markets/details/ebay/',
+        HTTP_HOST='testserver.com'
+    )
+    # when the success page is viewed
+    with mock.patch(
+        'directory_constants.constants.urls.SERVICES_SOO',
+        mocked_soo_landing
+    ):
+        response = client.get(
+            reverse('contact-us-selling-online-overseas-success'),
+            HTTP_HOST='testserver.com'
+        )
+    # for contact ingress urls user flow continues to landing page
+    assert response.context_data['next_url'] == mocked_soo_landing
     assert response.status_code == 200
     # and the ingress url is cleared
     assert mock_clear.call_count == 1

--- a/contact/tests/test_views.py
+++ b/contact/tests/test_views.py
@@ -758,7 +758,6 @@ success_urls = (
     reverse('contact-us-feedback-success'),
     reverse('contact-us-domestic-success'),
     reverse('contact-us-international-success'),
-    reverse('contact-us-selling-online-overseas-success'),
 )
 
 
@@ -817,7 +816,7 @@ def test_ingress_url_special_cases_on_success(
 
 @mock.patch('directory_cms_client.client.cms_api_client.lookup_by_slug')
 @mock.patch.object(views.FormSessionMixin.form_session_class, 'clear')
-def test_soo_ingress_url_special_cases_on_success(
+def test_always_landing_for_soo_ingress_url_on_success(
     mock_clear, mock_lookup_by_slug, client, rf
 ):
     mock_clear.return_value = None
@@ -825,8 +824,7 @@ def test_soo_ingress_url_special_cases_on_success(
         status_code=200,
         json_body={}
     )
-    # /selling-online-overseas/<path> should always return to soo landing
-    mocked_soo_landing = 'http://testserver.com/selling-online-overseas/'
+    mocked_soo_landing = 'http://testserver.com/test-path/'
     client.get(
         reverse('contact-us-soo', kwargs={'step': 'organisation'}),
         HTTP_REFERER=mocked_soo_landing + 'markets/details/ebay/',

--- a/contact/tests/test_views.py
+++ b/contact/tests/test_views.py
@@ -843,7 +843,8 @@ def test_soo_ingress_url_special_cases_on_success(
         )
     # for contact ingress urls user flow continues to landing page
     assert response.context_data['next_url'] == mocked_soo_landing
-    assert response.context_data['next_url_text'] == 'Go back to Selling Online Overseas'
+    assert response.context_data['next_url_text'] == \
+        'Go back to Selling Online Overseas'
     assert response.status_code == 200
     # and the ingress url is cleared
     assert mock_clear.call_count == 1

--- a/contact/views.py
+++ b/contact/views.py
@@ -501,6 +501,12 @@ class SellingOnlineOverseasSuccessView(BaseSuccessView):
             return urls.SERVICES_SOO
         return super().get_next_url()
 
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(
+            **kwargs,
+            next_url_text='Go back to Selling Online Overseas'
+        )
+
 
 class GuidanceView(mixins.GetCMSPageMixin, TemplateView):
     template_name = 'contact/guidance.html'

--- a/contact/views.py
+++ b/contact/views.py
@@ -496,10 +496,7 @@ class SellingOnlineOverseasSuccessView(BaseSuccessView):
     slug = cms.GREAT_CONTACT_US_FORM_SUCCESS_SOO_SLUG
 
     def get_next_url(self):
-        # If ingress url is from soo path always return to soo landing
-        if self.form_session.ingress_url.startswith(urls.SERVICES_SOO):
-            return urls.SERVICES_SOO
-        return super().get_next_url()
+        return urls.SERVICES_SOO
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(

--- a/contact/views.py
+++ b/contact/views.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
 from directory_components.mixins import CountryDisplayMixin
-from directory_constants.constants import cms
+from directory_constants.constants import cms, urls
 from directory_forms_api_client import actions
 from directory_forms_api_client.helpers import FormSessionMixin, Sender
 
@@ -494,6 +494,12 @@ class FeedbackSuccessView(BaseSuccessView):
 
 class SellingOnlineOverseasSuccessView(BaseSuccessView):
     slug = cms.GREAT_CONTACT_US_FORM_SUCCESS_SOO_SLUG
+
+    def get_next_url(self):
+        # If ingress url is from soo path always return to soo landing
+        if self.form_session.ingress_url.startswith(urls.SERVICES_SOO):
+            return urls.SERVICES_SOO
+        return super().get_next_url()
 
 
 class GuidanceView(mixins.GetCMSPageMixin, TemplateView):


### PR DESCRIPTION
There is a problem with soo to domestic and back to soo for not logged in users.

Before entering a contact form user is redirected to login page and it's going to be set as ingress url, instead of soo. There is no simple way of passing information of http referer from previous page before login to form session other than appending `ingress_url` param to `Apply via DIT` link in soo.

To avoid the hassle just redirect back to soo landing on soo contact success page.