### PR TITLE
[CMS-1666] Update path used to identify homepage

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -38,7 +38,7 @@ class LandingPageView(mixins.SetGA360ValuesForCMSPageMixin, TemplateView):
     @cached_property
     def page(self):
         response = cms_api_client.lookup_by_slug(
-            slug=slugs.GREAT_HOME,
+            slug='export-readiness-app',
             draft_token=self.request.GET.get('draft_token'),
         )
         return helpers.handle_cms_response_allow_404(response)


### PR DESCRIPTION
What was previously the `ExportReadinessApp` page has been replaced with a `HomePage` (now applied to all environments), but keeping the original page slug. The old home page will be deleted from CMS soon, so this update is to make the front-end request the new version instead.