### PR TITLE
Upgrade django to 1.11.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - No ticket - Fix card images being stretched, fix missing services page breadcrumbs
 - XOT-991 - add container div to community export advocates form to fix alignment issue
 - XOT-989 - add breadcrumb block to wizard-domestic to allow overrides
-
+- No ticket - Upgrade django to 1.11.23
 
 ## [2019.08.05](https://github.com/uktrade/great-domestic-ui/releases/tag/2019.08.05)
 [Full Changelog](https://github.com/uktrade/great-domestic-ui/compare/2019.08.01...2019.08.05)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django==1.11.22
+django==1.11.23
 django-environ==0.4.5
 django-extensions==1.9.0
 django-formtools==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ django-health-check==3.8.0  # via directory-healthcheck
 django-ipware==2.1.0
 django-recaptcha==1.2.0
 django-redis==4.8.0
-django==1.11.22
+django==1.11.23
 djangorestframework==3.9.1
 geoip2==2.9.0
 gunicorn==19.5.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -35,7 +35,7 @@ django-health-check==3.8.0  # via directory-healthcheck
 django-ipware==2.1.0
 django-recaptcha==1.2.0
 django-redis==4.8.0
-django==1.11.22
+django==1.11.23
 djangorestframework==3.9.1
 execnet==1.5.0            # via pytest-xdist
 flake8==3.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,6 +2840,6 @@ yargs@^7.0.0, yargs@^7.1.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-yarn@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.13.0.tgz#affa9c956739548024068532a902cf18c9cb523f"
+yarn@^1.17.3:
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.17.3.tgz#60e0b77d079eb78e753bb616f7592b51b6a9adce"


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] Upgraded any vulnerable dependencies.
 - [x] Requirements have been compiled.
 