### PR TITLE
Remove comma that causes error message to render incorrectly

### DIFF
--- a/marketaccess/forms.py
+++ b/marketaccess/forms.py
@@ -157,7 +157,7 @@ class ProblemDetailsForm(forms.Form):
         widget=Textarea,
         error_messages={
             'required': (
-                'Tell us what you’ve done to resolve your ',
+                'Tell us what you’ve done to resolve your '
                 'problem, even if this is your first step'
             )
         }


### PR DESCRIPTION
Before:

<img width="754" alt="Screen Shot 2019-08-30 at 13 10 35" src="https://user-images.githubusercontent.com/1481883/64020670-17cebb00-cb2a-11e9-9bf5-abb2e41b2c18.png">

After:

<img width="720" alt="Screen Shot 2019-08-30 at 13 10 44" src="https://user-images.githubusercontent.com/1481883/64020706-25844080-cb2a-11e9-9efe-56bdca4b69b9.png">
