### PR TITLE
Only include Aventri events in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - CI-540 - Brexit redirect
 
 ### Fixed bugs
+- No ticket - Fix search for "dit:Event" returning all events in Activity Stream
 - XOT-1042 - remove extra container markup
 - no ticket - Fix international urls in develop and staging.
 - no ticket - Silence captcha key checks

--- a/search/helpers.py
+++ b/search/helpers.py
@@ -121,12 +121,6 @@ def format_query(query, page):
                     }},
                     {'match': {
                         'type': {
-                            'query': 'Event',
-                            'boost': 10000
-                        }
-                    }},
-                    {'match': {
-                        'type': {
                             'query': 'dit:Article',
                             'boost': 10000
                         }
@@ -145,7 +139,7 @@ def format_query(query, page):
                     }},
                     {'match': {
                         'type': {
-                            'query': 'dit:Event',
+                            'query': 'dit:aventri:Event',
                             'boost': 10000
                         }
                     }}
@@ -157,12 +151,11 @@ def format_query(query, page):
                             'Opportunity',
                             'Market',
                             'Service',
-                            'Event',
                             'dit:Article',
                             'dit:Opportunity',
                             'dit:Market',
                             'dit:Service',
-                            'dit:Event'
+                            'dit:aventri:Event'
                         ]
                     }}
                 ]

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -21,7 +21,7 @@ def parse_search_results(content):
         ).rstrip()
 
     def format_events_url(result):
-        if "dit:Event" in result['type'] or "Event" in result['type']:
+        if "dit:aventri:Event" in result['type']:
             url = parse_url(result['url'])
             result['url'] = build_events_url(url.request_uri)
 
@@ -31,8 +31,7 @@ def parse_search_results(content):
 
     def format_display_type(result):
         mappings = {
-            'dit:Event': 'Event',
-            'Event': 'Event',
+            'dit:aventri:Event': 'Event',
             'dit:Opportunity': 'Export opportunity',
             'Opportunity': 'Export opportunity',
             'Market': 'Online marketplace',

--- a/search/tests/test_helpers.py
+++ b/search/tests/test_helpers.py
@@ -172,12 +172,6 @@ def test_format_query():
                     }},
                     {'match': {
                         'type': {
-                            'query': 'Event',
-                            'boost': 10000
-                        }
-                    }},
-                    {'match': {
-                        'type': {
                             'query': 'dit:Article',
                             'boost': 10000
                         }
@@ -196,7 +190,7 @@ def test_format_query():
                     }},
                     {'match': {
                         'type': {
-                            'query': 'dit:Event',
+                            'query': 'dit:aventri:Event',
                             'boost': 10000
                         }
                     }}
@@ -208,12 +202,11 @@ def test_format_query():
                             'Opportunity',
                             'Market',
                             'Service',
-                            'Event',
                             'dit:Article',
                             'dit:Opportunity',
                             'dit:Market',
                             'dit:Service',
-                            'dit:Event'
+                            'dit:aventri:Event'
                         ]
                     }}
                 ]

--- a/search/tests/test_serializers.py
+++ b/search/tests/test_serializers.py
@@ -84,7 +84,7 @@ r-2018) and the full",
                 '_id': 'dit:exportOpportunities:Event:1',
                 '_score': 0.18232156,
                 '_source': {
-                    'type': ['Document', 'dit:Event'],
+                    'type': ['Document', 'dit:aventri:Event'],
                     'title': 'Test Event URL Parsing',
                     'content': 'Great event',
                     'url': 'https://eu.eventscloud.com\


### PR DESCRIPTION
This depends on https://github.com/uktrade/activity-stream/commit/79b886913dc7fea4c0a24b9a425af966e4b3864d, which has now been released to production

-----
 - [x] Changelog entry added.
