### PR TITLE
XOT-1185 change sort param for country guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- XOT-1185 - change sort field for countries to arrange tiles wiht 'The' alphabetically by country name
 - XOT-1200 - autoplay video when watch video button opens modal
 - no ticket - change campaign component logo spacing (marketing request)
 - XOT-1117 - small spelling change

--- a/content/tests/test_templates.py
+++ b/content/tests/test_templates.py
@@ -19,7 +19,7 @@ def mock_get_page():
 @patch('directory_cms_client.client.cms_api_client.list_industry_tags', mock.MagicMock())
 def test_market_landing_pagination_page_next(mock_get_page, client):
 
-    child_page = {'title': 'Title', 'sub_heading': 'Markets subheading'}
+    child_page = {'title': 'Title',  'sorted_title': 'Title', 'sub_heading': 'Markets subheading'}
 
     page = {
         'title': 'test',
@@ -63,7 +63,7 @@ def test_market_landing_pagination_page_next(mock_get_page, client):
 @patch('directory_cms_client.client.cms_api_client.list_industry_tags', mock.MagicMock())
 def test_market_landing_pagination_page_next_not_in_html(mock_get_page, client):
 
-    child_page = {'title': 'Title', 'sub_heading': 'Markets subheading'}
+    child_page = {'title': 'Title', 'sorted_title': 'Title', 'sub_heading': 'Markets subheading'}
 
     page = {
         'title': 'test',

--- a/content/tests/test_views.py
+++ b/content/tests/test_views.py
@@ -336,7 +336,7 @@ def test_markets_page_filters(mock_countries, mock_page, rf):
             {'url': '/', 'title': 'great.gov.uk'},
             {'url': '/markets/', 'title': 'Markets'},
         ],
-        'child_pages': [{'title': 'Brazil'}, {'title': 'China'}, {'title': 'India'}, {'title': 'Japan'}],
+        'child_pages': [{'sorted_title': 'Brazil'}, {'sorted_title': 'China'}, {'sorted_title': 'India'}],
     }
 
     mock_page.return_value = create_response(page)
@@ -345,7 +345,7 @@ def test_markets_page_filters(mock_countries, mock_page, rf):
 
     filtered_countries = {
         'name': 'Tag name',
-        'countries': [{'title': 'India'}],
+        'countries': [{'sorted_title': 'India'}],
     }
 
     mock_countries.return_value = create_response(filtered_countries)
@@ -370,10 +370,10 @@ def test_markets_page_filters_sort_alphabetically(mock_countries, mock_page, rf)
             {'url': '/', 'title': 'great.gov.uk'},
             {'url': '/markets/', 'title': 'Markets'},
         ],
-        'child_pages': [{'title': 'India'}, {'title': 'Japan'}, {'title': 'Brazil'}, {'title': 'China'}],
+        'child_pages': [{'sorted_title': 'India'}, {'sorted_title': 'Japan'}, {'sorted_title': 'Brazil'}],
     }
 
-    sorted_child_pages = sorted(page['child_pages'], key=lambda x: x['title'])
+    sorted_child_pages = sorted(page['child_pages'], key=lambda x: x['sorted_title'])
 
     mock_page.return_value = create_response(page)
     content_list_industry_tags = [{}]
@@ -400,7 +400,7 @@ def test_markets_page_filters_invalid_param(mock_countries, mock_page, rf):
             {'url': '/', 'title': 'great.gov.uk'},
             {'url': '/markets/', 'title': 'Markets'},
         ],
-        'child_pages': [{'title': 'Brazil'}, {'title': 'China'}, {'title': 'India'}, {'title': 'Japan'}],
+        'child_pages': [{'sorted_title': 'Brazil'}, {'sorted_title': 'China'}, {'sorted_title': 'India'}],
     }
 
     mock_page.return_value = create_response(page)

--- a/content/views.py
+++ b/content/views.py
@@ -81,7 +81,7 @@ class MarketsPageView(CMSPageView):
             markets = self.page['child_pages']
             tag_name = None
 
-        filtered_countries = sorted(markets, key=lambda x: x['title'])
+        filtered_countries = sorted(markets, key=lambda x: x['sorted_title'])
 
         paginator = Paginator(filtered_countries, 12)
         pagination_page = paginator.page(self.request.GET.get('page', 1))


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if changing the UI) Add a printscreen to the PR
<img width="1325" alt="Screenshot 2019-11-15 at 12 09 07" src="https://user-images.githubusercontent.com/36957414/68950297-c42c4f00-07b3-11ea-8294-4b651e60ae5b.png">
