### PR TITLE
Remove gov uk tile on market page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- XOT-1275 - Remove gov uk tile on market page
 - XOT-1224 - add markets heading to cms and some design fixes
 - TT-1805 - Fix broken Search Sort Order backend
 - TT-2254 - Remove obsolete settings and code

--- a/content/templates/content/country_guide.html
+++ b/content/templates/content/country_guide.html
@@ -138,10 +138,6 @@
         {% url 'advice' as advice_url %}
         {% cta_card with_arrow=True image_url=need_help_image_url text="Read more advice about doing business abroad" url=advice_url %}
       </div>
-      <div class="column-full column-half-l column-third-xl margin-bottom-30 margin-bottom-0-xl">
-        {% static 'images/country-guide-gov-uk.png' as market_guide_image_url %}
-        {% cta_card with_arrow=True image_url=market_guide_image_url text=market_guide_cta_text url=page.help_market_guide_cta_link external_link=True %}
-      </div>
       <div class="column-full column-half-l column-third-xl margin-bottom-0">
         {% static 'images/country-guide-contact.png' as contact_us_image_url %}
         {% cta_card with_arrow=True image_url=contact_us_image_url text="Get in touch with one of our trade advisers" url=services_urls.office_finder %}


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] Ran the `make manage download_geolocation_data` command
 - [x] (if changing the UI) Add a printscreen to the PR

<img width="1193" alt="Screenshot 2020-01-21 at 15 47 20" src="https://user-images.githubusercontent.com/25905279/72819525-57c34580-3c65-11ea-95b2-7bcef66a1295.png">

