### PR TITLE
Vulnerability fixes - update django and pillow versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - No ticket - Upgrade markdown to fix vulnerability
 - No ticket - Fixed local export support form
 
+### Hotfix
+- No ticket - Upgrade django and pillow to fix vulnerability
+
 ## [2020.05.18](https://github.com/uktrade/great-domestic-ui/releases/tag/2020.05.18_1)
 [Full Changelog](https://github.com/uktrade/great-domestic-ui/compare/2020.04.22...2020.05.18_1)
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ django-formtools==2.1
 django-ipware==2.1.0
 django-recaptcha==2.0.5
 django-redis==4.10.0
-django==2.2.10
+django==2.2.13
 djangorestframework==3.10.3
 geoip2==3.0.0
 gunicorn==19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,31 +10,31 @@ certifi==2019.3.9         # via elastic-apm, requests, sentry-sdk
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==2.8         # via pyopenssl, requests
-dateparser==0.7.2         # via -r requirements.in
-directory-api-client==20.0.0  # via -r requirements.in
-directory-ch-client==2.1.0  # via -r requirements.in
+dateparser==0.7.2
+directory-api-client==20.0.0
+directory-ch-client==2.1.0
 directory-client-core==6.1.0  # via directory-api-client, directory-ch-client, directory-cms-client, directory-forms-api-client, directory-sso-api-client
-directory-cms-client==11.1.0  # via -r requirements.in
-directory-components==35.15.2  # via -r requirements.in
-directory-constants==20.11.0  # via -r requirements.in, directory-components
-directory-forms-api-client==5.3.0  # via -r requirements.in
-directory-healthcheck==2.0.0  # via -r requirements.in
-directory-sso-api-client==6.2.0  # via -r requirements.in
-directory-validators==6.0.1  # via -r requirements.in
-django-environ==0.4.5     # via -r requirements.in
-django-formtools==2.1     # via -r requirements.in
+directory-cms-client==11.1.0
+directory-components==35.15.2
+directory-constants==20.11.0
+directory-forms-api-client==5.3.0
+directory-healthcheck==2.0.0
+directory-sso-api-client==6.2.0
+directory-validators==6.0.1
+django-environ==0.4.5
+django-formtools==2.1
 django-health-check==3.8.0  # via directory-healthcheck
-django-ipware==2.1.0      # via -r requirements.in
-django-recaptcha==2.0.5   # via -r requirements.in
-django-redis==4.10.0      # via -r requirements.in
-django==2.2.10            # via -r requirements.in, directory-api-client, directory-ch-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, sigauth
-djangorestframework==3.10.3  # via -r requirements.in, sigauth
-elastic-apm==5.5.2        # via -r requirements.in
-geoip2==3.0.0             # via -r requirements.in
-gunicorn==19.9.0          # via -r requirements.in
+django-ipware==2.1.0
+django-recaptcha==2.0.5
+django-redis==4.10.0
+django==2.2.13
+djangorestframework==3.10.3
+elastic-apm==5.5.2
+geoip2==3.0.0
+gunicorn==19.9.0
 idna==2.8                 # via requests
 jsonschema==3.0.1         # via directory-components
-markdown2==2.3.9          # via -r requirements.in
+markdown2==2.3.9
 maxminddb==1.5.2          # via geoip2
 mohawk==0.3.4             # via sigauth
 monotonic==1.5            # via directory-ch-client, directory-client-core
@@ -47,17 +47,14 @@ python-dateutil==2.8.1    # via dateparser
 pytz==2017.2              # via dateparser, directory-validators, django, tzlocal
 redis==3.2.1              # via django-redis
 regex==2020.1.8           # via dateparser
-requests[security]==2.22.0  # via -r requirements.in, directory-api-client, directory-ch-client, directory-client-core, geoip2
-sentry-sdk==0.13.4        # via -r requirements.in
-sigauth==4.1.1            # via -r requirements.in, directory-client-core
+requests[security]==2.22.0
+sentry-sdk==0.13.4
+sigauth==4.1.1
 six==1.12.0               # via cryptography, jsonschema, mohawk, pyopenssl, pyrsistent, python-dateutil, w3lib
 soupsieve==1.9.4          # via beautifulsoup4
 sqlparse==0.3.0           # via django
 tzlocal==2.0.0            # via dateparser
-uk-postcode-utils==1.0    # via -r requirements.in
-urllib3==1.25.8           # via -r requirements.in, directory-validators, elastic-apm, geoip2, requests, sentry-sdk
+uk-postcode-utils==1.0
+urllib3==1.25.8
 w3lib==1.20.0             # via directory-client-core
-whitenoise==4.1.4         # via -r requirements.in
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+whitenoise==4.1.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,38 +12,38 @@ certifi==2018.4.16        # via elastic-apm, requests, sentry-sdk
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
-codecov==2.0.15           # via -r requirements_test.in
+codecov==2.0.15
 coverage==4.5.1           # via codecov, pytest-cov
 cryptography==2.8         # via pyopenssl, requests
-dateparser==0.7.2         # via -r requirements.in
-directory-api-client==20.0.0  # via -r requirements.in
-directory-ch-client==2.1.0  # via -r requirements.in
+dateparser==0.7.2
+directory-api-client==20.0.0
+directory-ch-client==2.1.0
 directory-client-core==6.1.0  # via directory-api-client, directory-ch-client, directory-cms-client, directory-forms-api-client, directory-sso-api-client
-directory-cms-client==11.1.0  # via -r requirements.in
-directory-components==35.15.2  # via -r requirements.in
-directory-constants==20.11.0  # via -r requirements.in, directory-components
-directory-forms-api-client==5.3.0  # via -r requirements.in
-directory-healthcheck==2.0.0  # via -r requirements.in
-directory-sso-api-client==6.2.0  # via -r requirements.in
-directory-validators==6.0.1  # via -r requirements.in
-django-environ==0.4.5     # via -r requirements.in
-django-formtools==2.1     # via -r requirements.in
+directory-cms-client==11.1.0
+directory-components==35.15.2
+directory-constants==20.11.0
+directory-forms-api-client==5.3.0
+directory-healthcheck==2.0.0
+directory-sso-api-client==6.2.0
+directory-validators==6.0.1
+django-environ==0.4.5
+django-formtools==2.1
 django-health-check==3.8.0  # via directory-healthcheck
-django-ipware==2.1.0      # via -r requirements.in
-django-recaptcha==2.0.5   # via -r requirements.in
-django-redis==4.10.0      # via -r requirements.in
-django==2.2.10            # via -r requirements.in, directory-api-client, directory-ch-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, sigauth
-djangorestframework==3.10.3  # via -r requirements.in, sigauth
-elastic-apm==5.5.2        # via -r requirements.in
+django-ipware==2.1.0
+django-recaptcha==2.0.5
+django-redis==4.10.0
+django==2.2.13
+djangorestframework==3.10.3
+elastic-apm==5.5.2
 execnet==1.5.0            # via pytest-xdist
-flake8==3.5.0             # via -r requirements_test.in
-freezegun==0.3.10         # via -r requirements_test.in
-geoip2==3.0.0             # via -r requirements.in
-gunicorn==19.9.0          # via -r requirements.in
+flake8==3.5.0
+freezegun==0.3.10
+geoip2==3.0.0
+gunicorn==19.9.0
 idna==2.7                 # via requests
 importlib-metadata==0.22  # via pluggy, pytest
 jsonschema==3.0.1         # via directory-components
-markdown2==2.3.9          # via -r requirements.in
+markdown2==2.3.9
 maxminddb==1.5.2          # via geoip2
 mccabe==0.6.1             # via flake8
 mohawk==0.3.4             # via sigauth
@@ -52,7 +52,7 @@ more-itertools==4.3.0     # via pytest, zipp
 olefile==0.44             # via directory-validators
 packaging==19.1           # via pytest
 pillow==6.2.2             # via directory-validators
-pip-tools==3.7.0          # via -r requirements_test.in
+pip-tools==3.7.0
 pluggy==0.13.0            # via pytest
 py==1.5.4                 # via pytest
 pycodestyle==2.3.1        # via flake8
@@ -61,31 +61,28 @@ pyflakes==1.6.0           # via flake8
 pyopenssl==19.1.0         # via requests
 pyparsing==2.4.2          # via packaging
 pyrsistent==0.15.2        # via jsonschema
-pytest-cov==2.7.1         # via -r requirements_test.in
-pytest-django==3.5.1      # via -r requirements_test.in
+pytest-cov==2.7.1
+pytest-django==3.5.1
 pytest-forked==0.2        # via pytest-xdist
-pytest-sugar==0.9.1       # via -r requirements_test.in
-pytest-xdist==1.29.0      # via -r requirements_test.in
-pytest==5.1.2             # via -r requirements_test.in, pytest-cov, pytest-django, pytest-forked, pytest-sugar, pytest-xdist
+pytest-sugar==0.9.1
+pytest-xdist==1.29.0
+pytest==5.1.2
 python-dateutil==2.7.3    # via dateparser, freezegun
 pytz==2017.2              # via dateparser, directory-validators, django, tzlocal
 redis==2.10.6             # via django-redis
 regex==2020.1.8           # via dateparser
-requests-mock==1.5.2      # via -r requirements_test.in
-requests[security]==2.22.0  # via -r requirements.in, codecov, directory-api-client, directory-ch-client, directory-client-core, geoip2, requests-mock
-sentry-sdk==0.13.4        # via -r requirements.in
-sigauth==4.1.1            # via -r requirements.in, directory-client-core
+requests-mock==1.5.2
+requests[security]==2.22.0
+sentry-sdk==0.13.4
+sigauth==4.1.1
 six==1.11.0               # via cryptography, freezegun, jsonschema, mohawk, more-itertools, packaging, pip-tools, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, requests-mock, w3lib
 soupsieve==1.9.4          # via beautifulsoup4
 sqlparse==0.3.0           # via django
 termcolor==1.1.0          # via pytest-sugar
 tzlocal==2.0.0            # via dateparser
-uk-postcode-utils==1.0    # via -r requirements.in
-urllib3==1.25.8           # via -r requirements.in, directory-validators, elastic-apm, geoip2, requests, sentry-sdk
+uk-postcode-utils==1.0
+urllib3==1.25.8
 w3lib==1.19.0             # via directory-client-core
 wcwidth==0.1.7            # via pytest
-whitenoise==4.1.4         # via -r requirements.in
+whitenoise==4.1.4
 zipp==0.6.0               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] Ran the `make manage download_geolocation_data` command
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.
