### PR TITLE
feat: support activitystream 1+2 simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- No ticket - added simultaneous support for Activity Stream 2 (Elasticsearch 7).
 
 ### Bugs fixed
 

--- a/search/helpers.py
+++ b/search/helpers.py
@@ -31,7 +31,16 @@ def parse_results(response, query, page):
         )
     else:
         results = serializers.parse_search_results(content)
+
+        # ActivityStream v1 / ElasticSearch v6 format - total is a raw int
         total_results = content['hits']['total']
+
+        # Check if we're using ActivityStream v2 (ElasticSearch v7) format by trying to grab the inner value
+        try:
+            total_results = total_results['value']
+        except TypeError:
+            pass
+
         total_pages = ceil(total_results/float(RESULTS_PER_PAGE))
 
     prev_pages = list(range(1, current_page))[-3:]

--- a/search/tests/test_helpers.py
+++ b/search/tests/test_helpers.py
@@ -26,10 +26,10 @@ show_last_page,first_item_number,last_item_number', (
         (9, [6, 7, 8], [10], True, False, 81, 90),
     )
 )
-def test_parse_results(page, prev_pages,
-                       next_pages, show_first_page,
-                       show_last_page, first_item_number,
-                       last_item_number):
+def test_parse_results_activitystream_v1(page, prev_pages,
+                                         next_pages, show_first_page,
+                                         show_last_page, first_item_number,
+                                         last_item_number):
     mock_results = json.dumps({
         'took': 17,
         'timed_out': False,
@@ -41,6 +41,86 @@ def test_parse_results(page, prev_pages,
         },
         'hits': {
             'total': 100,
+            'max_score': 0.2876821,
+            'hits': [{
+                '_index': 'objects__feed_id_first_feed__date_2019',
+                '_type': '_doc',
+                '_id': 'dit:exportOpportunities:Opportunity:2',
+                '_score': 0.2876821,
+                '_source': {
+                    'type': ['Document', 'dit:Opportunity'],
+                    'title': 'France - Data analysis services',
+                    'content':
+                    'The purpose of this contract is to analyze...',
+                    'url': 'www.great.gov.uk/opportunities/1'
+                }
+            }, {
+                '_index': 'objects__feed_id_first_feed__date_2019',
+                '_type': '_doc',
+                '_id': 'dit:exportOpportunities:Opportunity:2',
+                '_score': 0.18232156,
+                '_source': {
+                    'type': ['Document', 'dit:Opportunity'],
+                    'title': 'Germany - snow clearing',
+                    'content':
+                    'Winter services for the properties1) Former...',
+                    'url': 'www.great.gov.uk/opportunities/2'
+                }
+            }]
+        }
+    })
+    response = Mock(status=200, content=mock_results)
+    assert helpers.parse_results(response, "services", page) == {
+       'results': [{
+            'type': 'Export opportunity',
+            'title': 'France - Data analysis services',
+            'content': 'The purpose of this contract is to analyze...',
+            'url': 'www.great.gov.uk/opportunities/1'
+        },
+        {
+            'type': 'Export opportunity',
+            'title': 'Germany - snow clearing',
+            'content': 'Winter services for the properties1) Former...',
+            'url': 'www.great.gov.uk/opportunities/2'
+        }],
+       'total_results': 100,
+       'total_pages': 10,
+       'previous_page': page-1,
+       'next_page': page+1,
+       'prev_pages': prev_pages,
+       'next_pages': next_pages,
+       'show_first_page': show_first_page,
+       'show_last_page': show_last_page,
+       'first_item_number': first_item_number,
+       'last_item_number': last_item_number
+    }
+
+
+@pytest.mark.parametrize(
+    'page,prev_pages,next_pages,show_first_page,\
+show_last_page,first_item_number,last_item_number', (
+        (2, [1], [3, 4, 5], False, True, 11, 20),
+        (9, [6, 7, 8], [10], True, False, 81, 90),
+    )
+)
+def test_parse_results_activitystream_v2(page, prev_pages,
+                                         next_pages, show_first_page,
+                                         show_last_page, first_item_number,
+                                         last_item_number):
+    mock_results = json.dumps({
+        'took': 17,
+        'timed_out': False,
+        '_shards': {
+            'total': 4,
+            'successful': 4,
+            'skipped': 0,
+            'failed': 0
+        },
+        'hits': {
+            'total': {
+                'value': 100,
+                'relation': 'eq',
+            },
             'max_score': 0.2876821,
             'hits': [{
                 '_index': 'objects__feed_id_first_feed__date_2019',

--- a/search/tests/test_views.py
+++ b/search/tests/test_views.py
@@ -14,63 +14,70 @@ def test_search_view(client, settings):
     """ We mock the call to ActivityStream """
 
     with patch('search.helpers.search_with_activitystream') as search:
-        mock_results = json.dumps({
-            'took': 17,
-            'timed_out': False,
-            '_shards': {
-                'total': 4,
-                'successful': 4,
-                'skipped': 0,
-                'failed': 0
-            },
-            'hits': {
-                'total': 5,
-                'max_score': 0.2876821,
-                'hits': [{
-                    '_index': 'objects__feed_id_first_feed__date_2019',
-                    '_type': '_doc',
-                    '_id': 'dit:exportOpportunities:Opportunity:2',
-                    '_score': 0.2876821,
-                    '_source': {
-                        'type': ['Document', 'dit:Opportunity'],
-                        'title': 'France - Data analysis services',
-                        'content':
-                        'The purpose of this contract is to analyze...',
-                        'url': 'www.great.gov.uk/opportunities/1'
-                    }
-                }, {
-                    '_index': 'objects__feed_id_first_feed__date_2019',
-                    '_type': '_doc',
-                    '_id': 'dit:exportOpportunities:Opportunity:2',
-                    '_score': 0.18232156,
-                    '_source': {
-                        'type': ['Document', 'dit:Opportunity'],
-                        'title': 'Germany - snow clearing',
-                        'content':
-                        'Winter services for the properties1) Former...',
-                        'url': 'www.great.gov.uk/opportunities/2'
-                    }
-                }]
-            }
-        })
-        search.return_value = Mock(status_code=200, content=mock_results)
+        """The check for ActivityStream v2 can be removed when great-domestic-ui has been fully
+        switched over via config.
+        """
+        activity_stream_v1_total = 5
+        activity_stream_v2_total = {"value": 5, "relation": "eq"}
 
-        response = client.get(reverse('search'), data={'q': 'services'})
-        context = response.context_data
+        for total in [activity_stream_v1_total, activity_stream_v2_total]:
+            mock_results = json.dumps({
+                'took': 17,
+                'timed_out': False,
+                '_shards': {
+                    'total': 4,
+                    'successful': 4,
+                    'skipped': 0,
+                    'failed': 0
+                },
+                'hits': {
+                    'total': total,
+                    'max_score': 0.2876821,
+                    'hits': [{
+                        '_index': 'objects__feed_id_first_feed__date_2019',
+                        '_type': '_doc',
+                        '_id': 'dit:exportOpportunities:Opportunity:2',
+                        '_score': 0.2876821,
+                        '_source': {
+                            'type': ['Document', 'dit:Opportunity'],
+                            'title': 'France - Data analysis services',
+                            'content':
+                            'The purpose of this contract is to analyze...',
+                            'url': 'www.great.gov.uk/opportunities/1'
+                        }
+                    }, {
+                        '_index': 'objects__feed_id_first_feed__date_2019',
+                        '_type': '_doc',
+                        '_id': 'dit:exportOpportunities:Opportunity:2',
+                        '_score': 0.18232156,
+                        '_source': {
+                            'type': ['Document', 'dit:Opportunity'],
+                            'title': 'Germany - snow clearing',
+                            'content':
+                            'Winter services for the properties1) Former...',
+                            'url': 'www.great.gov.uk/opportunities/2'
+                        }
+                    }]
+                }
+            })
+            search.return_value = Mock(status_code=200, content=mock_results)
 
-        assert response.status_code == 200
-        assert context['results'] == [
+            response = client.get(reverse('search'), data={'q': 'services'})
+            context = response.context_data
+
+            assert response.status_code == 200
+            assert context['results'] == [
                 {
-                  'type': 'Export opportunity',
-                  'title': 'France - Data analysis services',
-                  'content': 'The purpose of this contract is to analyze...',
-                  'url': 'www.great.gov.uk/opportunities/1'
+                    'type': 'Export opportunity',
+                    'title': 'France - Data analysis services',
+                    'content': 'The purpose of this contract is to analyze...',
+                    'url': 'www.great.gov.uk/opportunities/1'
                 },
                 {
-                  'type': 'Export opportunity',
-                  'title': 'Germany - snow clearing',
-                  'content': 'Winter services for the properties1) Former...',
-                  'url': 'www.great.gov.uk/opportunities/2'
+                    'type': 'Export opportunity',
+                    'title': 'Germany - snow clearing',
+                    'content': 'Winter services for the properties1) Former...',
+                    'url': 'www.great.gov.uk/opportunities/2'
                 }
             ]
 


### PR DESCRIPTION
We've (Data Infrastructure) deployed a new version of Activity Stream
running Elasticsearch 7, which has a slightly updated API. The 'total'
key is an object in ES7 and a plain int in ES6. We want to support both
activity streams for the transition so that we don't need to sync the
config change exactly.

To do (delete all that do not apply):

 - [x] Changelog entry added.