### PR TITLE
feature: remove Aventri events from the search ElasticSearch query

### DIFF
--- a/search/helpers.py
+++ b/search/helpers.py
@@ -145,12 +145,6 @@ def format_query(query, page):
                             'query': 'dit:Service',
                             'boost': 20000
                         }
-                    }},
-                    {'match': {
-                        'type': {
-                            'query': 'dit:aventri:Event',
-                            'boost': 10000
-                        }
                     }}
                 ],
                 'filter': [
@@ -164,7 +158,6 @@ def format_query(query, page):
                             'dit:Opportunity',
                             'dit:Market',
                             'dit:Service',
-                            'dit:aventri:Event'
                         ]
                     }}
                 ]

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -2,7 +2,6 @@ import markdown2
 from functools import partial
 from urllib.parse import urljoin
 from bs4 import BeautifulSoup
-from urllib3.util import parse_url
 
 from django.utils.text import Truncator
 
@@ -20,18 +19,12 @@ def parse_search_results(content):
             BeautifulSoup(html, "html.parser").findAll(text=True)
         ).rstrip()
 
-    def format_events_url(result):
-        if "dit:aventri:Event" in result['type']:
-            url = parse_url(result['url'])
-            result['url'] = build_events_url(url.request_uri)
-
     def abridge_long_contents(result):
         if 'content' in result:
             result['content'] = Truncator(result['content']).chars(160)
 
     def format_display_type(result):
         mappings = {
-            'dit:aventri:Event': 'Event',
             'dit:Opportunity': 'Export opportunity',
             'Opportunity': 'Export opportunity',
             'Market': 'Online marketplace',
@@ -54,7 +47,6 @@ def parse_search_results(content):
     # It also removes unneccessary \n added by the markdown library
     for result in results:
         strip_html(result)
-        format_events_url(result)
         format_display_type(result)
         abridge_long_contents(result)
 

--- a/search/tests/test_helpers.py
+++ b/search/tests/test_helpers.py
@@ -267,12 +267,6 @@ def test_format_query():
                             'query': 'dit:Service',
                             'boost': 20000
                         }
-                    }},
-                    {'match': {
-                        'type': {
-                            'query': 'dit:aventri:Event',
-                            'boost': 10000
-                        }
                     }}
                 ],
                 'filter': [
@@ -286,7 +280,6 @@ def test_format_query():
                             'dit:Opportunity',
                             'dit:Market',
                             'dit:Service',
-                            'dit:aventri:Event'
                         ]
                     }}
                 ]

--- a/search/tests/test_serializers.py
+++ b/search/tests/test_serializers.py
@@ -78,18 +78,6 @@ r-2018) and the full",
                     'title': 'Test No URL',
                     'content': 'Here is the content'
                 }
-            }, {
-                '_index': 'objects__feed_id_first_feed__date_2019',
-                '_type': '_doc',
-                '_id': 'dit:exportOpportunities:Event:1',
-                '_score': 0.18232156,
-                '_source': {
-                    'type': ['Document', 'dit:aventri:Event'],
-                    'title': 'Test Event URL Parsing',
-                    'content': 'Great event',
-                    'url': 'https://eu.eventscloud.com\
-/ehome/index.php?eventid=200188836&'
-                }
             }]
         }
     }
@@ -122,10 +110,4 @@ r-2018) and the full",
         'type': 'Article',
         'title': 'Test No URL',
         'content': 'Here is the content',
-    }, {
-        'type': 'Event',
-        'title': 'Test Event URL Parsing',
-        'content': 'Great event',
-        'url': 'https://www.events.great.gov.uk/\
-ehome/index.php?eventid=200188836&'
     }]


### PR DESCRIPTION
The ElasticSearch/Activity Stream feed for Aventri is currently disabled but will be re-enabled soon. However once it is re-enabled it will return all events from the Aventri API, in contrast to the original feed which did some filtering. This will cause undesired search results to appear on great.gov.uk if the ElasticSearch query remains as it is.

Therefore this PR removes Aventri events from the ElasticSearch query and a separate PR will be raised at a later stage to update the query with the relevant filters.

