### PR TITLE
GBAU-918 Fix reCaptcha token timeout problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Implemented enhancements
 
 ### Bugs fixed
-
+- GBAU-918 Fix reCaptcha token timeout.
 
 ## [1.1.0](https://github.com/uktrade/great-domestic-ui/releases/tag/1.1.0)
 [Full Changelog](https://github.com/uktrade/great-domestic-ui/compare/1.0.0...1.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Implemented enhancements
 
 ### Bugs fixed
-- GBAU-918 Fix reCaptcha token timeout.
+- GBAU-918 Fix reCaptcha token timeout
 
 ## [1.1.0](https://github.com/uktrade/great-domestic-ui/releases/tag/1.1.0)
 [Full Changelog](https://github.com/uktrade/great-domestic-ui/compare/1.0.0...1.1.0)

--- a/core/templates/captcha/includes/js_v3.html
+++ b/core/templates/captcha/includes/js_v3.html
@@ -1,0 +1,17 @@
+<script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
+<script>
+  const form = document.querySelector("main form")
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    grecaptcha.ready(function() {
+        grecaptcha.execute('{{ public_key }}', {action: 'form'})
+        .then(function(token) {
+            console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Setting input value...")
+            var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
+            element.value = token;
+            form.submit();
+        });
+    });
+  });
+</script>

--- a/core/templates/captcha/includes/js_v3.html
+++ b/core/templates/captcha/includes/js_v3.html
@@ -1,16 +1,16 @@
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
 <script>
-  const form = document.querySelector("main form")
-
-  form.addEventListener('submit', (event) => {
-    event.preventDefault();
-    grecaptcha.ready(function() {
-        grecaptcha.execute('{{ public_key }}', {action: 'form'})
+  // attach reCapture check on form submit to stop token expiry.
+  grecaptcha.ready(function() {
+    const form = document.querySelector("main form")
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      grecaptcha.execute('{{ public_key }}', {action: 'form'})
         .then(function(token) {
-            console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Setting input value...")
-            var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
-            element.value = token;
-            form.submit();
+          console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Setting input value...")
+          var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
+          element.value = token;
+          form.submit();
         });
     });
   });


### PR DESCRIPTION
On changing to reCapcha V3, there is now a token that expires 2 minutes after activation.  This has been causing some users to have failed form submissions.
This change overrides the default captcha implementation and activates the token, only on the user pressing the submit button - hence the token expiry will no longer be a problem.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if hotfix) Has made PR into develop too
