### PR TITLE
noticket: Upgrade Django to 2.2.22

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ django-formtools==2.1
 django-ipware==2.1.0
 django-recaptcha==2.0.5
 django-redis==4.10.0
-django==2.2.21
+django==2.2.22
 djangorestframework==3.11.2
 geoip2==3.0.0
 gunicorn==19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,57 +4,165 @@
 #
 #    pip-compile requirements.in
 #
-attrs==19.1.0             # via jsonschema
-beautifulsoup4==4.8.0     # via directory-components
-certifi==2019.3.9         # via elastic-apm, requests, sentry-sdk
-cffi==1.13.2              # via cryptography
-chardet==3.0.4            # via requests
-cryptography==3.3.2       # via pyopenssl, requests
+attrs==19.1.0
+    # via jsonschema
+beautifulsoup4==4.8.0
+    # via directory-components
+certifi==2019.3.9
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+cffi==1.13.2
+    # via cryptography
+chardet==3.0.4
+    # via requests
+cryptography==3.3.2
+    # via
+    #   pyopenssl
+    #   requests
 dateparser==0.7.2
+    # via -r requirements.in
 directory-api-client==20.0.0
+    # via -r requirements.in
 directory-ch-client==2.1.0
-directory-client-core==6.1.0  # via directory-api-client, directory-ch-client, directory-cms-client, directory-forms-api-client, directory-sso-api-client
+    # via -r requirements.in
+directory-client-core==6.1.0
+    # via
+    #   directory-api-client
+    #   directory-ch-client
+    #   directory-cms-client
+    #   directory-forms-api-client
+    #   directory-sso-api-client
 directory-cms-client==11.1.0
+    # via -r requirements.in
 directory-components==36.2.0
-directory-constants==20.28.0  # via directory-components
+    # via -r requirements.in
+directory-constants==20.28.0
+    # via directory-components
 directory-forms-api-client==6.0.0
+    # via -r requirements.in
 directory-healthcheck==2.0.0
+    # via -r requirements.in
 directory-sso-api-client==6.2.0
+    # via -r requirements.in
 directory-validators==6.0.5
+    # via -r requirements.in
 django-environ==0.4.5
+    # via -r requirements.in
 django-formtools==2.1
-django-health-check==3.8.0  # via directory-healthcheck
+    # via -r requirements.in
+django-health-check==3.8.0
+    # via directory-healthcheck
 django-ipware==2.1.0
+    # via -r requirements.in
 django-recaptcha==2.0.5
+    # via -r requirements.in
 django-redis==4.10.0
-django==2.2.21
+    # via -r requirements.in
+django==2.2.22
+    # via
+    #   -r requirements.in
+    #   directory-api-client
+    #   directory-ch-client
+    #   directory-client-core
+    #   directory-components
+    #   directory-constants
+    #   directory-healthcheck
+    #   directory-validators
+    #   django-formtools
+    #   django-recaptcha
+    #   django-redis
+    #   djangorestframework
+    #   sigauth
 djangorestframework==3.11.2
+    # via
+    #   -r requirements.in
+    #   sigauth
 elastic-apm==5.5.2
+    # via -r requirements.in
 geoip2==3.0.0
+    # via -r requirements.in
 gunicorn==19.9.0
-idna==2.8                 # via requests
-jsonschema==3.0.1         # via directory-components
+    # via -r requirements.in
+idna==2.8
+    # via requests
+jsonschema==3.0.1
+    # via directory-components
 markdown2==2.3.9
-maxminddb==1.5.2          # via geoip2
-mohawk==0.3.4             # via sigauth
-monotonic==1.5            # via directory-ch-client, directory-client-core
-olefile==0.44             # via directory-validators
-pillow==8.1.2             # via directory-validators
-pycparser==2.19           # via cffi
-pyopenssl==19.1.0         # via requests
-pyrsistent==0.15.2        # via jsonschema
-python-dateutil==2.8.1    # via dateparser
-pytz==2017.2              # via dateparser, directory-validators, django, tzlocal
-redis==3.2.1              # via django-redis
-regex==2020.1.8           # via dateparser
+    # via -r requirements.in
+maxminddb==1.5.2
+    # via geoip2
+mohawk==0.3.4
+    # via sigauth
+monotonic==1.5
+    # via
+    #   directory-ch-client
+    #   directory-client-core
+olefile==0.44
+    # via directory-validators
+pillow==8.1.2
+    # via directory-validators
+pycparser==2.19
+    # via cffi
+pyopenssl==19.1.0
+    # via requests
+pyrsistent==0.15.2
+    # via jsonschema
+python-dateutil==2.8.1
+    # via dateparser
+pytz==2017.2
+    # via
+    #   dateparser
+    #   directory-validators
+    #   django
+    #   tzlocal
+redis==3.2.1
+    # via django-redis
+regex==2020.1.8
+    # via dateparser
 requests[security]==2.25.1
+    # via
+    #   -r requirements.in
+    #   directory-api-client
+    #   directory-ch-client
+    #   directory-client-core
+    #   geoip2
 sentry-sdk==0.13.4
+    # via -r requirements.in
 sigauth==4.1.1
-six==1.12.0               # via cryptography, jsonschema, mohawk, pyopenssl, pyrsistent, python-dateutil, w3lib
-soupsieve==1.9.4          # via beautifulsoup4
-sqlparse==0.3.0           # via django
-tzlocal==2.0.0            # via dateparser
+    # via
+    #   -r requirements.in
+    #   directory-client-core
+six==1.12.0
+    # via
+    #   cryptography
+    #   jsonschema
+    #   mohawk
+    #   pyopenssl
+    #   pyrsistent
+    #   python-dateutil
+    #   w3lib
+soupsieve==1.9.4
+    # via beautifulsoup4
+sqlparse==0.3.0
+    # via django
+tzlocal==2.0.0
+    # via dateparser
 uk-postcode-utils==1.0
+    # via -r requirements.in
 urllib3==1.25.8
-w3lib==1.20.0             # via directory-client-core
+    # via
+    #   -r requirements.in
+    #   directory-validators
+    #   elastic-apm
+    #   geoip2
+    #   requests
+    #   sentry-sdk
+w3lib==1.20.0
+    # via directory-client-core
 whitenoise==4.1.4
+    # via -r requirements.in
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -1,6 +1,6 @@
 -r requirements.in
 
-pip-tools
+pip-tools>=6.1.0
 pytest>=4.4.0<5.0.0
 pytest-cov==2.7.1
 pytest-django>=3.5.1<4.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,86 +4,255 @@
 #
 #    pip-compile requirements_test.in
 #
-apipkg==1.5               # via execnet
-atomicwrites==1.1.5       # via pytest
-attrs==18.1.0             # via jsonschema, packaging, pytest
-beautifulsoup4==4.8.0     # via directory-components
-certifi==2018.4.16        # via elastic-apm, requests, sentry-sdk
-cffi==1.13.2              # via cryptography
-chardet==3.0.4            # via requests
-click==7.0                # via pip-tools
+apipkg==1.5
+    # via execnet
+atomicwrites==1.1.5
+    # via pytest
+attrs==18.1.0
+    # via
+    #   jsonschema
+    #   packaging
+    #   pytest
+beautifulsoup4==4.8.0
+    # via directory-components
+certifi==2018.4.16
+    # via
+    #   elastic-apm
+    #   requests
+    #   sentry-sdk
+cffi==1.13.2
+    # via cryptography
+chardet==3.0.4
+    # via requests
+click==7.0
+    # via pip-tools
 codecov==2.0.15
-coverage==4.5.1           # via codecov, pytest-cov
-cryptography==3.3.2       # via pyopenssl, requests
+    # via -r requirements_test.in
+coverage==4.5.1
+    # via
+    #   codecov
+    #   pytest-cov
+cryptography==3.3.2
+    # via
+    #   pyopenssl
+    #   requests
 dateparser==0.7.2
+    # via -r requirements.in
 directory-api-client==20.0.0
+    # via -r requirements.in
 directory-ch-client==2.1.0
-directory-client-core==6.1.0  # via directory-api-client, directory-ch-client, directory-cms-client, directory-forms-api-client, directory-sso-api-client
+    # via -r requirements.in
+directory-client-core==6.1.0
+    # via
+    #   directory-api-client
+    #   directory-ch-client
+    #   directory-cms-client
+    #   directory-forms-api-client
+    #   directory-sso-api-client
 directory-cms-client==11.1.0
+    # via -r requirements.in
 directory-components==36.2.0
-directory-constants==20.28.0  # via directory-components
+    # via -r requirements.in
+directory-constants==20.28.0
+    # via directory-components
 directory-forms-api-client==6.0.0
+    # via -r requirements.in
 directory-healthcheck==2.0.0
+    # via -r requirements.in
 directory-sso-api-client==6.2.0
+    # via -r requirements.in
 directory-validators==6.0.5
+    # via -r requirements.in
 django-environ==0.4.5
+    # via -r requirements.in
 django-formtools==2.1
-django-health-check==3.8.0  # via directory-healthcheck
+    # via -r requirements.in
+django-health-check==3.8.0
+    # via directory-healthcheck
 django-ipware==2.1.0
+    # via -r requirements.in
 django-recaptcha==2.0.5
+    # via -r requirements.in
 django-redis==4.10.0
-django==2.2.21
+    # via -r requirements.in
+django==2.2.22
+    # via
+    #   -r requirements.in
+    #   directory-api-client
+    #   directory-ch-client
+    #   directory-client-core
+    #   directory-components
+    #   directory-constants
+    #   directory-healthcheck
+    #   directory-validators
+    #   django-formtools
+    #   django-recaptcha
+    #   django-redis
+    #   djangorestframework
+    #   sigauth
 djangorestframework==3.11.2
+    # via
+    #   -r requirements.in
+    #   sigauth
 elastic-apm==5.5.2
-execnet==1.5.0            # via pytest-xdist
+    # via -r requirements.in
+execnet==1.5.0
+    # via pytest-xdist
 flake8==3.5.0
+    # via -r requirements_test.in
 freezegun==0.3.10
+    # via -r requirements_test.in
 geoip2==3.0.0
+    # via -r requirements.in
 gunicorn==19.9.0
-idna==2.7                 # via requests
-importlib-metadata==4.0.1  # via pluggy, pytest
-jsonschema==3.0.1         # via directory-components
+    # via -r requirements.in
+idna==2.7
+    # via requests
+importlib-metadata==4.0.1
+    # via
+    #   pep517
+    #   pluggy
+    #   pytest
+jsonschema==3.0.1
+    # via directory-components
 markdown2==2.3.9
-maxminddb==1.5.2          # via geoip2
-mccabe==0.6.1             # via flake8
-mohawk==0.3.4             # via sigauth
-monotonic==1.5            # via directory-ch-client, directory-client-core
-more-itertools==4.3.0     # via pytest
-olefile==0.44             # via directory-validators
-packaging==19.1           # via pytest
-pillow==8.1.2             # via directory-validators
-pip-tools==3.7.0
-pluggy==0.13.0            # via pytest
+    # via -r requirements.in
+maxminddb==1.5.2
+    # via geoip2
+mccabe==0.6.1
+    # via flake8
+mohawk==0.3.4
+    # via sigauth
+monotonic==1.5
+    # via
+    #   directory-ch-client
+    #   directory-client-core
+more-itertools==4.3.0
+    # via pytest
+olefile==0.44
+    # via directory-validators
+packaging==19.1
+    # via pytest
+pep517==0.10.0
+    # via pip-tools
+pillow==8.1.2
+    # via directory-validators
+pip-tools==6.1.0
+    # via -r requirements_test.in
+pluggy==0.13.0
+    # via pytest
 py==1.10.0
-pycodestyle==2.3.1        # via flake8
-pycparser==2.19           # via cffi
-pyflakes==1.6.0           # via flake8
-pyopenssl==19.1.0         # via requests
-pyparsing==2.4.2          # via packaging
-pyrsistent==0.15.2        # via jsonschema
+    # via
+    #   -r requirements_test.in
+    #   pytest
+pycodestyle==2.3.1
+    # via flake8
+pycparser==2.19
+    # via cffi
+pyflakes==1.6.0
+    # via flake8
+pyopenssl==19.1.0
+    # via requests
+pyparsing==2.4.2
+    # via packaging
+pyrsistent==0.15.2
+    # via jsonschema
 pytest-cov==2.7.1
+    # via -r requirements_test.in
 pytest-django==3.5.1
-pytest-forked==0.2        # via pytest-xdist
+    # via -r requirements_test.in
+pytest-forked==0.2
+    # via pytest-xdist
 pytest-sugar==0.9.1
+    # via -r requirements_test.in
 pytest-xdist==1.29.0
+    # via -r requirements_test.in
 pytest==5.1.2
-python-dateutil==2.7.3    # via dateparser, freezegun
-pytz==2017.2              # via dateparser, directory-validators, django, tzlocal
-redis==2.10.6             # via django-redis
-regex==2020.1.8           # via dateparser
+    # via
+    #   -r requirements_test.in
+    #   pytest-cov
+    #   pytest-django
+    #   pytest-forked
+    #   pytest-sugar
+    #   pytest-xdist
+python-dateutil==2.7.3
+    # via
+    #   dateparser
+    #   freezegun
+pytz==2017.2
+    # via
+    #   dateparser
+    #   directory-validators
+    #   django
+    #   tzlocal
+redis==2.10.6
+    # via django-redis
+regex==2020.1.8
+    # via dateparser
 requests-mock==1.5.2
+    # via -r requirements_test.in
 requests[security]==2.25.1
+    # via
+    #   -r requirements.in
+    #   codecov
+    #   directory-api-client
+    #   directory-ch-client
+    #   directory-client-core
+    #   geoip2
+    #   requests-mock
 sentry-sdk==0.13.4
+    # via -r requirements.in
 sigauth==4.1.1
-six==1.11.0               # via cryptography, freezegun, jsonschema, mohawk, more-itertools, packaging, pip-tools, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, requests-mock, w3lib
-soupsieve==1.9.4          # via beautifulsoup4
-sqlparse==0.3.0           # via django
-termcolor==1.1.0          # via pytest-sugar
-typing-extensions==3.7.4.3  # via importlib-metadata
-tzlocal==2.0.0            # via dateparser
+    # via
+    #   -r requirements.in
+    #   directory-client-core
+six==1.11.0
+    # via
+    #   cryptography
+    #   freezegun
+    #   jsonschema
+    #   mohawk
+    #   more-itertools
+    #   packaging
+    #   pyopenssl
+    #   pyrsistent
+    #   pytest-xdist
+    #   python-dateutil
+    #   requests-mock
+    #   w3lib
+soupsieve==1.9.4
+    # via beautifulsoup4
+sqlparse==0.3.0
+    # via django
+termcolor==1.1.0
+    # via pytest-sugar
+toml==0.10.2
+    # via pep517
+typing-extensions==3.7.4.3
+    # via importlib-metadata
+tzlocal==2.0.0
+    # via dateparser
 uk-postcode-utils==1.0
+    # via -r requirements.in
 urllib3==1.25.8
-w3lib==1.19.0             # via directory-client-core
-wcwidth==0.1.7            # via pytest
+    # via
+    #   -r requirements.in
+    #   directory-validators
+    #   elastic-apm
+    #   geoip2
+    #   requests
+    #   sentry-sdk
+w3lib==1.19.0
+    # via directory-client-core
+wcwidth==0.1.7
+    # via pytest
 whitenoise==4.1.4
-zipp==3.4.1               # via importlib-metadata
+    # via -r requirements.in
+zipp==3.4.1
+    # via
+    #   importlib-metadata
+    #   pep517
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip
+# setuptools


### PR DESCRIPTION
Also pin pip-tools version so we don't get it downgraded and unable to run without being upgraded again

 - [X] Existing changelog entry is still appropriate
 - [X] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [X] (if updating requirements) Requirements have been compiled.
