### PR TITLE
GP2-2988 - Make SOO contact form name fields editable if not already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - GP2-2784 - Bump directory components with header and footer updates
 
 ### Bugs fixed
+- GP2-2988 - Make SOO contact form name fields editable if not already populated.
 - GP2-2556 - Update verbose class implementation
 - GBAU-957 - redirect /companion/ to digital-companion.ava-digi.de
 

--- a/contact/forms.py
+++ b/contact/forms.py
@@ -464,15 +464,9 @@ class BusinessDetailsForm(ConsentFieldMixin, forms.Form):
 class SellingOnlineOverseasContactDetails(forms.Form):
     contact_first_name = forms.CharField(
         label='First name',
-        disabled=True,
-        required=False,
-        container_css_classes='border-active-blue read-only-input-container',
     )
     contact_last_name = forms.CharField(
         label='Last name',
-        disabled=True,
-        required=False,
-        container_css_classes='border-active-blue read-only-input-container',
     )
     contact_email = forms.EmailField(
         label='Your email',
@@ -487,6 +481,25 @@ class SellingOnlineOverseasContactDetails(forms.Form):
         label='I prefer to be contacted by email',
         required=False,
     )
+
+    def _set_name_field_editability(self):
+        # If cetain fields lack content, allow each one to be editable.
+        for fieldname in [
+            'contact_first_name',
+            'contact_last_name',
+        ]:
+            if self.initial.get(fieldname):
+                self.fields[fieldname].required = False
+                self.fields[fieldname].disabled = True
+                # note that we can't set .container_css_classes, but we can do this:
+                self.fields[fieldname]._container_css_classes = 'border-active-blue read-only-input-container'
+            else:
+                self.fields[fieldname].required = True
+                self.fields[fieldname].disabled = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._set_name_field_editability()
 
 
 class SellingOnlineOverseasApplicant(forms.Form):

--- a/contact/tests/test_forms.py
+++ b/contact/tests/test_forms.py
@@ -451,3 +451,125 @@ def test_postcode_validation(valid_request_export_support_form_data):
     valid_request_export_support_form_data['company_postcode'] = 'W1A W1A'
     form = forms.ExportSupportForm(data=valid_request_export_support_form_data)
     assert form.is_valid() is False
+
+
+def test_selling_online_overseas_contact_details_form__editable_fields():
+
+    form_1 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_first_name': 'Alice',
+            'contact_last_name': 'McTest',
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_1.fields['contact_first_name'].disabled is True
+    assert form_1.fields['contact_first_name'].required is False
+    assert form_1.fields['contact_first_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_1.fields['contact_last_name'].disabled is True
+    assert form_1.fields['contact_last_name'].required is False
+    assert form_1.fields['contact_last_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_1.fields['contact_email'].disabled is True
+    assert form_1.fields['contact_email'].required is False
+    assert form_1.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_1.fields['phone'].disabled is False
+    assert form_1.fields['phone'].required is True
+    assert form_1.fields['phone'].container_css_classes == 'form-group '
+
+    form_2 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_first_name': 'Alice',
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_2.fields['contact_first_name'].disabled is True
+    assert form_2.fields['contact_first_name'].required is False
+    assert form_2.fields['contact_first_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_2.fields['contact_last_name'].disabled is False
+    assert form_2.fields['contact_last_name'].required is True
+    assert form_2.fields['contact_last_name'].container_css_classes == 'form-group '
+
+    assert form_2.fields['contact_email'].disabled is True
+    assert form_2.fields['contact_email'].required is False
+    assert form_2.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_2.fields['phone'].disabled is False
+    assert form_2.fields['phone'].required is True
+    assert form_2.fields['phone'].container_css_classes == 'form-group '
+
+    form_3 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_last_name': 'McTest',
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_3.fields['contact_first_name'].disabled is False
+    assert form_3.fields['contact_first_name'].required is True
+    assert form_3.fields['contact_first_name'].container_css_classes == 'form-group '
+
+    assert form_3.fields['contact_last_name'].disabled is True
+    assert form_3.fields['contact_last_name'].required is False
+    assert form_3.fields['contact_last_name'].container_css_classes == 'border-active-blue read-only-input-container '
+
+    assert form_3.fields['contact_email'].disabled is True
+    assert form_3.fields['contact_email'].required is False
+    assert form_3.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_3.fields['phone'].disabled is False
+    assert form_3.fields['phone'].required is True
+    assert form_3.fields['phone'].container_css_classes == 'form-group '
+
+    form_4 = forms.SellingOnlineOverseasContactDetails(
+        initial={
+            'contact_email': 'alice@example.com',
+            'phone': '998877665544',
+        }
+    )
+    assert form_4.fields['contact_first_name'].disabled is False
+    assert form_4.fields['contact_first_name'].required is True
+    assert form_4.fields['contact_first_name'].container_css_classes == 'form-group '
+
+    assert form_4.fields['contact_last_name'].disabled is False
+    assert form_4.fields['contact_last_name'].required is True
+    assert form_4.fields['contact_last_name'].container_css_classes == 'form-group '
+
+    assert form_4.fields['contact_email'].disabled is True
+    assert form_4.fields['contact_email'].required is False
+    assert form_4.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_4.fields['phone'].disabled is False
+    assert form_4.fields['phone'].required is True
+    assert form_4.fields['phone'].container_css_classes == 'form-group '
+
+    form_5 = forms.SellingOnlineOverseasContactDetails(initial={})
+    assert form_5.fields['contact_first_name'].disabled is False
+    assert form_5.fields['contact_first_name'].required is True
+    assert form_5.fields['contact_first_name'].container_css_classes == 'form-group '
+
+    assert form_5.fields['contact_last_name'].disabled is False
+    assert form_5.fields['contact_last_name'].required is True
+    assert form_5.fields['contact_last_name'].container_css_classes == 'form-group '
+
+    assert form_5.fields['contact_email'].disabled is True
+    assert form_5.fields['contact_email'].required is False
+    assert form_5.fields['contact_email'].container_css_classes == (
+        'border-active-blue read-only-input-container padding-bottom-0 margin-bottom-30 '
+    )
+
+    assert form_5.fields['phone'].disabled is False
+    assert form_5.fields['phone'].required is True
+    assert form_5.fields['phone'].container_css_classes == 'form-group '


### PR DESCRIPTION
BUGFIX: Make the name fields in the SOO contact wizard to still be editable if the first and/or last name is not yet known

This is needed because Great V2 allows users to sign up without providing a first or last name, which would then cause the overall wizard to 500.

**NOTE THAT this fix is has been SEPARATELY applied to great-cms, for the contact that have been migrated from V1 into V2, but this PR is to get the fix out to current production faster**

Tests work at the Python level, but tested manually, too, of course.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GP2-2988
- [X] Jira ticket has the correct status.
- [X] [Changelog](CHANGELOG.md) entry added.

### Reviewing help

- [X] Includes screenshot(s)

**BEFORE** - see https://uktrade.atlassian.net/wiki/spaces/Great/pages/2681405487/SOO+applications+-+make+first+and+last+name+fields+editable

<img width="963" alt="Screenshot 2021-07-05 at 11 14 11" src="https://user-images.githubusercontent.com/101457/124463749-3be52e00-dd8b-11eb-8bc9-c4996be90b59.png">


**AFTER**

<img width="443" alt="Screenshot 2021-07-01 at 18 04 15" src="https://user-images.githubusercontent.com/101457/124307801-3e177480-db60-11eb-8d34-25c9aafb6773.png">


(and if details are already present...)
<img width="437" alt="Screenshot 2021-07-01 at 18 04 26" src="https://user-images.githubusercontent.com/101457/124307800-3d7ede00-db60-11eb-877b-08fe7d5a7a2d.png">


### Merging

- [X] reviewers can merge this